### PR TITLE
Add mathjax 2.7 as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     },
     "dependencies": {
         "mathjax-node": "0.5.2",
+        "mathjax": "^2.7.0",
         "q": "^1.1.2",
         "crc": "^3.2.1"
     },


### PR DESCRIPTION
Version 3.0.0 of mathjax was just released which breaks the version of `mathjax-node` used by the plugin. This change adds a dependency on the the 2.7.0 branch of `mathjax`.